### PR TITLE
Feat/recipe repository class

### DIFF
--- a/src/classes/RecipeRepository.js
+++ b/src/classes/RecipeRepository.js
@@ -3,7 +3,6 @@ class RecipeRepository {
     this.recipes = recipeData ? [recipeData] : [];
     this.recipesByTag = [];
     this.recipesByName = [];
-    // this.id = userID || 0
   }
 
   filterRecipesByTag(tag) {

--- a/src/classes/RecipeRepository.js
+++ b/src/classes/RecipeRepository.js
@@ -1,8 +1,9 @@
 class RecipeRepository {
   constructor(recipeData) {
-    this.recipes = [recipeData];
+    this.recipes = recipeData ? [recipeData] : [];
     this.recipesByTag = [];
     this.recipesByName = [];
+    // this.id = userID || 0
   }
 
   filterRecipesByTag(tag) {

--- a/test/RecipeRepository-test.js
+++ b/test/RecipeRepository-test.js
@@ -73,6 +73,11 @@ describe('Recipe', () => {
 
   it('Should be able to take in data', () => {
     expect(cookies.recipes).to.deep.equal([recipe1]);
+
+    const porkChops = new RecipeRepository();
+    expect(porkChops).to.be.an.instanceOf(RecipeRepository);
+    expect(porkChops.recipes).to.deep.equal([]);
+
   })
 
   it('Should filter recipes into a list based on a tag', () => {
@@ -120,4 +125,5 @@ describe('Recipe', () => {
     cookies.filterRecipesByTag(23) 
     expect(cookies.recipesByTag).to.deep.equal([]);
   })
+
 })


### PR DESCRIPTION
This PR adds a sad path test and fix for the case that RecipeRepository is initialized without any recipe data being passed in. 

We were hoping to be able to use this class for saving and filtering recipes for the User class, this fix should make that more smooth